### PR TITLE
fix 'dotnet build' command error for net35

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build:
 build_script:
   - cmd: dotnet build -c Release src
 test_script:
-  - cmd: dotnet test -c Release src
+  - cmd: dotnet test -c Release src\Senparc.NeuChar.Tests\
 artifacts:
   - path: '**\*.nupkg'
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ build:
   parallel: true
 build_script:
   - cmd: dotnet build -c Release src
-#test_script:
-#  - cmd: dotnet test -c Release src\Senparc.NeuChar.Tests\
+test_script:
+  - cmd: dotnet test -c Release src
 artifacts:
   - path: '**\*.nupkg'
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ build:
   parallel: true
 build_script:
   - cmd: dotnet build -c Release src
-test_script:
-  - cmd: dotnet test -c Release src\Senparc.NeuChar.Tests\
+#test_script:
+#  - cmd: dotnet test -c Release src\Senparc.NeuChar.Tests\
 artifacts:
   - path: '**\*.nupkg'
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: 1.0.0.{build}
+image:
+  - Visual Studio 2017
+pull_requests:
+  do_not_increment_build_number: true
+branches:
+  only:
+    - master
+skip_branch_with_pr: true
+configuration: Release
+before_build:
+  - cmd: dotnet restore src
+build:
+  verbosity: minimal
+  parallel: true
+build_script:
+  - cmd: dotnet build -c Release src
+test_script:
+  - cmd: dotnet test -c Release src
+artifacts:
+  - path: '**\*.nupkg'
+nuget:
+  disable_publish_on_pr: true
+#deploy:
+#  provider: NuGet
+#  api_key:
+#    secure: <Your secret>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <Net35FrameworkPathOverride>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client;$(WINDIR)\Microsoft.NET\Framework\v2.0.50727</Net35FrameworkPathOverride>
+  </PropertyGroup>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,20 @@
 ﻿<Project>
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <Net35FrameworkPathOverride>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client;$(WINDIR)\Microsoft.NET\Framework\v2.0.50727</Net35FrameworkPathOverride>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" version="16.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="IDisposableAnalyzers" Version="2.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/src/Senparc.NeuChar.Tests/Helpers/EntityHelperTests.cs
+++ b/src/Senparc.NeuChar.Tests/Helpers/EntityHelperTests.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Senparc.NeuChar.Entities;
 using Senparc.NeuChar.Helpers;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml.Linq;
 
 namespace Senparc.NeuChar.Tests.Helpers
@@ -36,10 +33,7 @@ namespace Senparc.NeuChar.Tests.Helpers
 
         public class RequestMessageComponentVerifyTicket
         {
-            public  RequestInfoType InfoType
-            {
-                get { return RequestInfoType.component_verify_ticket; }
-            }
+            public RequestInfoType InfoType => RequestInfoType.component_verify_ticket;
             public string AppId { get; set; }
             public DateTimeOffset CreateTime { get; set; }
 
@@ -50,14 +44,14 @@ namespace Senparc.NeuChar.Tests.Helpers
         [TestMethod]
         public void FillEntityWithXml()
         {
-            var xml = @"<xml>
+            string xml = @"<xml>
   <AppId><![CDATA[wxbbd3f07e2945cf2a]]></AppId>
   <CreateTime>1536250240</CreateTime>
   <InfoType><![CDATA[component_verify_ticket]]></InfoType>
   <ComponentVerifyTicket><![CDATA[ticket@@@oj3_KoMMnlH2SZbBs89CAzABbNF3Wfr12AFbIg19aKeLSgebFJXPE9tS60X38ab-kG5a08oskSWVdHEklNCAhA]]></ComponentVerifyTicket>
 </xml>";
-            var entity = new RequestMessageComponentVerifyTicket();
-            var doc = XDocument.Parse(xml);
+            RequestMessageComponentVerifyTicket entity = new RequestMessageComponentVerifyTicket();
+            XDocument doc = XDocument.Parse(xml);
             EntityHelper.FillEntityWithXml(entity, doc);
 
             Assert.AreEqual("wxbbd3f07e2945cf2a", entity.AppId);

--- a/src/Senparc.NeuChar.Tests/Senparc.NeuChar.Tests.csproj
+++ b/src/Senparc.NeuChar.Tests/Senparc.NeuChar.Tests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Configurations>Debug;Release;Test</Configurations>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,10 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Senparc.NeuChar\Senparc.NeuChar.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="App_Data\WeChat_OfficialAccount\2018-11-18\" />
   </ItemGroup>
 
 </Project>

--- a/src/Senparc.NeuChar.Tests/Senparc.NeuChar.Tests.csproj
+++ b/src/Senparc.NeuChar.Tests/Senparc.NeuChar.Tests.csproj
@@ -2,21 +2,20 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <Configurations>Debug;Release;Test</Configurations>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Senparc.Weixin.MP" Version="16.6.2-preview6" />
-    <PackageReference Include="Senparc.Weixin.WxOpen" Version="3.3.2-preview6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="Moq" Version="4.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.*" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.*" />
+    <PackageReference Include="Senparc.Weixin.MP" Version="16.*" />
+    <PackageReference Include="Senparc.Weixin.WxOpen" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Senparc.NeuChar.sln
+++ b/src/Senparc.NeuChar.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.156
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.NeuChar", "Senparc.NeuChar\Senparc.NeuChar.csproj", "{B5F4440F-31ED-4CB7-B723-54D4B40EE4D6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.NeuChar", "Senparc.NeuChar\Senparc.NeuChar.csproj", "{0E884956-6FD3-4346-A45E-09059E814F38}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.NeuChar.Tests", "Senparc.NeuChar.Tests\Senparc.NeuChar.Tests.csproj", "{D18EE5FA-DBCF-4989-821E-F21AF805133C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.NeuChar.App", "Senparc.NeuChar.App\Senparc.NeuChar.App.csproj", "{7D1538D5-4842-44AD-8B16-96A2347113E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Senparc.NeuChar.App", "Senparc.NeuChar.App\Senparc.NeuChar.App.csproj", "{5DB3871E-712F-47BF-A13F-6DC9AA186C42}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Senparc.NeuChar.Tests", "Senparc.NeuChar.Tests\Senparc.NeuChar.Tests.csproj", "{4F2EE047-FE72-4A6D-B741-5B374728072E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,22 +16,24 @@ Global
 		Test|Any CPU = Test|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B5F4440F-31ED-4CB7-B723-54D4B40EE4D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B5F4440F-31ED-4CB7-B723-54D4B40EE4D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B5F4440F-31ED-4CB7-B723-54D4B40EE4D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B5F4440F-31ED-4CB7-B723-54D4B40EE4D6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B5F4440F-31ED-4CB7-B723-54D4B40EE4D6}.Test|Any CPU.ActiveCfg = Test|Any CPU
-		{B5F4440F-31ED-4CB7-B723-54D4B40EE4D6}.Test|Any CPU.Build.0 = Test|Any CPU
-		{D18EE5FA-DBCF-4989-821E-F21AF805133C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D18EE5FA-DBCF-4989-821E-F21AF805133C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D18EE5FA-DBCF-4989-821E-F21AF805133C}.Test|Any CPU.ActiveCfg = Test|Any CPU
-		{D18EE5FA-DBCF-4989-821E-F21AF805133C}.Test|Any CPU.Build.0 = Test|Any CPU
-		{5DB3871E-712F-47BF-A13F-6DC9AA186C42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5DB3871E-712F-47BF-A13F-6DC9AA186C42}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5DB3871E-712F-47BF-A13F-6DC9AA186C42}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5DB3871E-712F-47BF-A13F-6DC9AA186C42}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5DB3871E-712F-47BF-A13F-6DC9AA186C42}.Test|Any CPU.ActiveCfg = Debug|Any CPU
-		{5DB3871E-712F-47BF-A13F-6DC9AA186C42}.Test|Any CPU.Build.0 = Debug|Any CPU
+		{0E884956-6FD3-4346-A45E-09059E814F38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E884956-6FD3-4346-A45E-09059E814F38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E884956-6FD3-4346-A45E-09059E814F38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E884956-6FD3-4346-A45E-09059E814F38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E884956-6FD3-4346-A45E-09059E814F38}.Test|Any CPU.ActiveCfg = Test|Any CPU
+		{0E884956-6FD3-4346-A45E-09059E814F38}.Test|Any CPU.Build.0 = Test|Any CPU
+		{7D1538D5-4842-44AD-8B16-96A2347113E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D1538D5-4842-44AD-8B16-96A2347113E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D1538D5-4842-44AD-8B16-96A2347113E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D1538D5-4842-44AD-8B16-96A2347113E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D1538D5-4842-44AD-8B16-96A2347113E4}.Test|Any CPU.ActiveCfg = Test|Any CPU
+		{7D1538D5-4842-44AD-8B16-96A2347113E4}.Test|Any CPU.Build.0 = Test|Any CPU
+		{4F2EE047-FE72-4A6D-B741-5B374728072E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F2EE047-FE72-4A6D-B741-5B374728072E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F2EE047-FE72-4A6D-B741-5B374728072E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F2EE047-FE72-4A6D-B741-5B374728072E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F2EE047-FE72-4A6D-B741-5B374728072E}.Test|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F2EE047-FE72-4A6D-B741-5B374728072E}.Test|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Senparc.NeuChar/Senparc.NeuChar.csproj
+++ b/src/Senparc.NeuChar/Senparc.NeuChar.csproj
@@ -5,6 +5,7 @@
     <Version>0.6.4</Version>
     <AssemblyName>Senparc.NeuChar</AssemblyName>
     <RootNamespace>Senparc.NeuChar</RootNamespace>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
 
     <Description>

--- a/src/Senparc.NeuChar/Senparc.NeuChar.csproj
+++ b/src/Senparc.NeuChar/Senparc.NeuChar.csproj
@@ -5,7 +5,7 @@
     <Version>0.6.4</Version>
     <AssemblyName>Senparc.NeuChar</AssemblyName>
     <RootNamespace>Senparc.NeuChar</RootNamespace>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(Net35FrameworkPathOverride)</FrameworkPathOverride>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
 
     <Description>


### PR DESCRIPTION
error MSB3644: The reference assemblies for framework ".NETFramework,Version=v3.5" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.