### PR TITLE
MASSSENDJOBFINISH 事件增加 ArticleUrlResult 节点

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin/
 *.user
 /src/Senparc.NeuChar.Tests/App_Data/WeChat_OfficialAccount/*
 /src/ProjectFileManager
+/src/.idea

--- a/src/Senparc.NeuChar.Tests/Helpers/EntityHelperTests.cs
+++ b/src/Senparc.NeuChar.Tests/Helpers/EntityHelperTests.cs
@@ -2,6 +2,7 @@
 using Senparc.NeuChar.Helpers;
 using System;
 using System.Xml.Linq;
+using Senparc.NeuChar.Entities;
 
 namespace Senparc.NeuChar.Tests.Helpers
 {
@@ -17,14 +18,17 @@ namespace Senparc.NeuChar.Tests.Helpers
             /// 推送component_verify_ticket协议
             /// </summary>
             component_verify_ticket,
+
             /// <summary>
             /// 推送取消授权通知
             /// </summary>
             unauthorized,
+
             /// <summary>
             /// 更新授权
             /// </summary>
             updateauthorized,
+
             /// <summary>
             /// 授权成功通知
             /// </summary>
@@ -38,6 +42,61 @@ namespace Senparc.NeuChar.Tests.Helpers
             public DateTimeOffset CreateTime { get; set; }
 
             public string ComponentVerifyTicket { get; set; }
+        }
+
+        public class RequestMessageEvent_MassSendJobFinish
+        {
+            public string Event { get; set; }
+
+            /// <summary>
+            /// 群发的结构，为“send success”或“send fail”或“err(num)”。当send success时，也有可能因用户拒收公众号的消息、系统错误等原因造成少量用户接收失败。err(num)是审核失败的具体原因，可能的情况如下：
+            /// err(10001), //涉嫌广告 err(20001), //涉嫌政治 err(20004), //涉嫌社会 err(20002), //涉嫌色情 err(20006), //涉嫌违法犯罪 err(20008), //涉嫌欺诈 err(20013), //涉嫌版权 err(22000), //涉嫌互推(互相宣传) err(21000), //涉嫌其他
+            /// </summary>
+            public string Status { get; set; }
+
+            /// <summary>
+            /// group_id下粉丝数；或者openid_list中的粉丝数
+            /// </summary>
+            public int TotalCount { get; set; }
+
+            /// <summary>
+            /// 过滤（过滤是指，有些用户在微信设置不接收该公众号的消息）后，准备发送的粉丝数，原则上，FilterCount = SentCount + ErrorCount
+            /// </summary>
+            public int FilterCount { get; set; }
+
+            /// <summary>
+            /// 发送成功的粉丝数
+            /// </summary>
+            public int SentCount { get; set; }
+
+            /// <summary>
+            /// 发送失败的粉丝数
+            /// </summary>
+            public int ErrorCount { get; set; }
+
+            /// <summary>
+            /// 群发的消息ID
+            /// </summary>
+            public long MsgID { get; set; }
+
+            [Obsolete("请使用MsgID")]
+            public new long MsgId { get; set; }
+
+            /// <summary>
+            /// CopyrightCheckResult
+            /// </summary>
+            public CopyrightCheckResult CopyrightCheckResult { get; set; }
+
+            /// <summary>
+            /// 群发文章的url
+            /// </summary>
+            public ArticleUrlResult ArticleUrlResult { get; set; }
+
+            public RequestMessageEvent_MassSendJobFinish()
+            {
+                CopyrightCheckResult = new CopyrightCheckResult();
+                ArticleUrlResult = new ArticleUrlResult();
+            }
         }
 
 
@@ -56,12 +115,14 @@ namespace Senparc.NeuChar.Tests.Helpers
 
             Assert.AreEqual("wxbbd3f07e2945cf2a", entity.AppId);
             //Assert.AreEqual("CreateTime", entity.AppId);
-            Assert.AreEqual(RequestInfoType.component_verify_ticket, entity.InfoType);//只读
-            Assert.AreEqual("ticket@@@oj3_KoMMnlH2SZbBs89CAzABbNF3Wfr12AFbIg19aKeLSgebFJXPE9tS60X38ab-kG5a08oskSWVdHEklNCAhA", entity.ComponentVerifyTicket);
+            Assert.AreEqual(RequestInfoType.component_verify_ticket, entity.InfoType); //只读
+            Assert.AreEqual(
+                "ticket@@@oj3_KoMMnlH2SZbBs89CAzABbNF3Wfr12AFbIg19aKeLSgebFJXPE9tS60X38ab-kG5a08oskSWVdHEklNCAhA",
+                entity.ComponentVerifyTicket);
 
             try
             {
-                entity = null;//测试 null 的情况
+                entity = null; //测试 null 的情况
                 EntityHelper.FillEntityWithXml(entity, doc);
                 Assert.Fail();
             }
@@ -70,5 +131,75 @@ namespace Senparc.NeuChar.Tests.Helpers
                 Console.WriteLine("抛出异常是正确的");
             }
         }
+
+        [TestMethod]
+        public void FillRequestMessageEvent_MassSendJobFinishWithXmlTest()
+        {
+            var xml = @"<xml>
+<ToUserName><![CDATA[gh_a96a4a619366]]></ToUserName>
+<FromUserName><![CDATA[oR5Gjjl_eiZoUpGozMo7dbBJ362A]]></FromUserName>
+<CreateTime>1394524295</CreateTime>
+<MsgType><![CDATA[event]]></MsgType>
+<Event><![CDATA[MASSSENDJOBFINISH]]></Event>
+<MsgID>1988</MsgID>
+<Status><![CDATA[sendsuccess]]></Status>
+<TotalCount>100</TotalCount>
+<FilterCount>80</FilterCount>
+<SentCount>75</SentCount>
+<ErrorCount>5</ErrorCount>
+<CopyrightCheckResult> 
+    <Count>2</Count>  
+    <ResultList> 
+      <item> 
+        <ArticleIdx>1</ArticleIdx>  
+        <UserDeclareState>0</UserDeclareState>  
+        <AuditState>2</AuditState>  
+        <OriginalArticleUrl><![CDATA[Url_1]]></OriginalArticleUrl>  
+        <OriginalArticleType>1</OriginalArticleType>  
+        <CanReprint>1</CanReprint>  
+        <NeedReplaceContent>1</NeedReplaceContent>  
+        <NeedShowReprintSource>1</NeedShowReprintSource> 
+      </item>  
+      <item> 
+        <ArticleIdx>2</ArticleIdx>  
+        <UserDeclareState>0</UserDeclareState>  
+        <AuditState>2</AuditState>  
+        <OriginalArticleUrl><![CDATA[Url_2]]></OriginalArticleUrl>  
+        <OriginalArticleType>1</OriginalArticleType>  
+        <CanReprint>1</CanReprint>  
+        <NeedReplaceContent>1</NeedReplaceContent>  
+        <NeedShowReprintSource>1</NeedShowReprintSource> 
+      </item> 
+    </ResultList>  
+    <CheckState>2</CheckState> 
+  </CopyrightCheckResult> 
+  <ArticleUrlResult>
+    <Count>1</Count>
+    <ResultList>
+      <item>
+        <ArticleIdx>1</ArticleIdx>
+        <ArticleUrl><![CDATA[http://mp.weixin.qq.com/s/sssss]]></ArticleUrl>
+      </item>
+    </ResultList>
+  </ArticleUrlResult>
+</xml>";
+
+            var entity = new RequestMessageEvent_MassSendJobFinish();
+            XDocument doc = XDocument.Parse(xml);
+
+            EntityHelper.FillEntityWithXml(entity, doc);
+
+
+            Assert.IsTrue(entity.CopyrightCheckResult.Count == 2);
+
+            Assert.IsTrue(entity.CopyrightCheckResult.ResultList[1].item.OriginalArticleUrl == "Url_2");
+
+
+            Assert.IsTrue(entity.ArticleUrlResult.Count == 1);
+
+            Assert.IsTrue(entity.ArticleUrlResult.ResultList[0].item.ArticleUrl == "http://mp.weixin.qq.com/s/sssss");
+        }
+
+
     }
 }

--- a/src/Senparc.NeuChar/Entities/Base/Request/Interfaces/Event/ArticleUrlResult.cs
+++ b/src/Senparc.NeuChar/Entities/Base/Request/Interfaces/Event/ArticleUrlResult.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+
+namespace Senparc.NeuChar.Entities
+{
+
+
+    /// <summary>
+    ///     群发文章的url
+    /// </summary>
+    public class ArticleUrlResult
+    {
+        public int Count { get; set; }
+
+        public List<ArticleUrlResult_ResultList> ResultList { get; set; }
+
+        public ArticleUrlResult()
+        {
+            ResultList=new List<ArticleUrlResult_ResultList>();
+        }
+    }
+
+    public class ArticleUrlResult_ResultList
+    {
+        public ArticleUrlResult_ResultList_Item item { get; set; }
+
+        public ArticleUrlResult_ResultList()
+        {
+            item=new ArticleUrlResult_ResultList_Item();
+        }
+    }
+
+    public class ArticleUrlResult_ResultList_Item
+    {
+
+        public int ArticleIdx { get; set; }
+
+        public string ArticleUrl { get; set; }
+    }
+}

--- a/src/Senparc.NeuChar/Helpers/EntityHelper.cs
+++ b/src/Senparc.NeuChar/Helpers/EntityHelper.cs
@@ -196,6 +196,17 @@ namespace Senparc.NeuChar.Helpers
                                     }
                                     prop.SetValue(entity, resultList, null);
                                 }
+                                else if (genericArgumentTypeName == "ArticleUrlResult_ResultList")//RequestMessageEvent_MassSendJobFinish
+                                {
+                                    List<ArticleUrlResult_ResultList> resultList = new List<ArticleUrlResult_ResultList>();
+                                    foreach (var item in root.Elements("ResultList").Elements("item"))
+                                    {
+                                        ArticleUrlResult_ResultList resultItem = new ArticleUrlResult_ResultList();
+                                        FillEntityWithXml(resultItem.item, new XDocument(item));
+                                        resultList.Add(resultItem);
+                                    }
+                                    prop.SetValue(entity, resultList, null);
+                                }
                                 //企业微信
                                 else if (genericArguments[0].Name == "MpNewsArticle")
                                 {
@@ -251,6 +262,14 @@ namespace Senparc.NeuChar.Helpers
                         case "CopyrightCheckResult_ResultList_Item":
                             FillClassValue<CopyrightCheckResult_ResultList_Item>(entity, root, "item", prop);
                             break;
+                        case "ArticleUrlResult":
+                            FillClassValue<ArticleUrlResult>(entity, root, propName, prop);
+                            break;
+                        case "ArticleUrlResult_ResultList_Item":
+                            FillClassValue<ArticleUrlResult_ResultList_Item>(entity, root, "item", prop);
+                            break;
+                        
+                        
                         #region 企业号
                         /* 暂时放在Work.dll中
                                                 case "AgentType":


### PR DESCRIPTION
WeiXinMPSDK 中xml转entity 用了NeuChar 来处理

https://github.com/JeffreySu/WeiXinMPSDK/blob/c092a1e3d650d49b757c45d532a0f871d8b6e2ba/src/Senparc.Weixin.MP/Senparc.Weixin.MP/RequestMessageFactory.cs#L90

NeuChar 发布后，才能增加WeiXinMPSDK 中RequestMessageEvent_MassSendJobFinish 的ArticleUrlResult 节点