### PR TITLE
MessageHandlerHelper 中添加使用 Unicode 拆分字符的方法

### DIFF
--- a/src/Senparc.NeuChar.Tests/Helpers/MessageHandlerHelperTests.cs
+++ b/src/Senparc.NeuChar.Tests/Helpers/MessageHandlerHelperTests.cs
@@ -36,5 +36,35 @@ namespace Senparc.NeuChar.Helpers.Tests
 
 
         }
+
+        [TestMethod]
+        public void ChunkStringByUnicode()
+        {
+            var limit = 10;
+            var text = "Senparc.NeuChar🤝 跨平台信息交互🔄标准🌍。使用 NeuChar 标准💬可以跨平台🌐兼容不同平台的交互🔀信息设置，一次设置🚀，多平台共享📱🖥。";
+
+            var results = MessageHandlerHelper.ChunkStringByUnicode(text, limit);
+
+            foreach (var result in results)
+            {
+                var bytes = Encoding.UTF8.GetBytes(result);
+                Assert.IsTrue(bytes.Length <= limit);
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleLimitedTextAsync()
+        {
+            var limit = 10;
+            var text = "Senparc.NeuChar🤝 跨平台信息交互🔄标准🌍。使用 NeuChar 标准💬可以跨平台🌐兼容不同平台的交互🔀信息设置，一次设置🚀，多平台共享📱🖥。";
+
+            var results = await MessageHandlerHelper.TryHandleLimitedText(text, limit, chunk =>
+            {
+                return Task.FromResult(chunk);
+            });
+
+            Assert.AreEqual(text, string.Join(string.Empty, results));
+        }
+
     }
 }


### PR DESCRIPTION
🔀 Add Unicode chunking for handling limited text
  
- Added a new method `ChunkStringByUnicode` in `MessageHandlerHelper` to split text into chunks based on Unicode characters.
- Added a new method `TryHandleLimitedText` in `MessageHandlerHelper` to handle long text by splitting it into chunks and processing each chunk separately.
- Added unit tests for the new methods in `MessageHandlerHelperTests`.

The changes enable handling of long text content by splitting it into smaller chunks based on Unicode characters. This allows for more efficient processing and handling of text content within the specified byte limit.
